### PR TITLE
Updates dependencies and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 ## Prerequisites
 
 * Node.js v0.10+
-* libvips v7.38.5+
+* libvips v8.0+
 
-On Ubuntu 14.04, installing libvips is as easy as :
+On Ubuntu 14.x and 15.04 the default libvips package is not compatible with versions of Sharp.
 
-```
-sudo apt-get install libvips-dev
-```
+To manually install VIPS from source, follow the instructions at [Build VIPS on Ubuntu](http://www.vips.ecs.soton.ac.uk/index.php?title=Build_on_Ubuntu)
 
-For other system, more info can be seen at [sharp Prerequisites](https://github.com/lovell/sharp#prerequisites). Or, if you'd like to build from source, head over to [libvips](https://github.com/jcupitt/libvips)
+The source is available from the [VipsWiki site](http://www.vips.ecs.soton.ac.uk/index.php?title=VIPS).
+
+
+For other system, more info can be seen at [sharp Prerequisites](https://github.com/lovell/sharp#prerequisites).
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sharp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Gulp plugin to resize image using sharp (libvips binding for nodejs)",
   "main": "index.js",
   "scripts": {
@@ -40,9 +40,9 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "event-stream": "^3.1.7",
-    "gulp-util": "^3.0.1",
-    "lodash": "^2.4.1",
-    "sharp": "^0.6.2"
+    "event-stream": "^3.3.*",
+    "gulp-util": "^3.0.*",
+    "lodash": "^3.9.*",
+    "sharp": "^0.10.*"
   }
 }


### PR DESCRIPTION
Fixes dependencies to use newer libvips v8.0+ compatible versions of Sharp.
Updates documentation to include instructions on installtion of VIPS from source, since current packages do no provide a compatible version of libvips. 